### PR TITLE
Fixed typo in userConfigFiles description

### DIFF
--- a/locales/es.json
+++ b/locales/es.json
@@ -255,7 +255,7 @@
               },
               "userConfigFiles": {
                 "description": "Usar archivos de configuración específicos (como '.babelrc') en vez de usar 'package.json'.",
-                "name": "Usar archivos de confifuración"
+                "name": "Usar archivos de configuración"
               }
             },
             "configuration": {


### PR DESCRIPTION
The description field in userConfigFiles description has a typo.